### PR TITLE
Improve bot restarting

### DIFF
--- a/bot/commands/administrative.py
+++ b/bot/commands/administrative.py
@@ -677,6 +677,20 @@ BUG (2020/06/21): An uneven amount of colons will prevent
 
 
 
+    @commands.command(name='syncslash')
+    @checks.is_bot_owner()
+    @commands.cooldown(1, 15)
+    async def client_sync_slash(self, ctx):
+        """Synchronize slash commands."""
+        async with ctx.typing():
+            await self.bot.slash.sync_all_commands()
+
+        await ctx.send('Synced slash commands.')
+
+
+
+
+
 
 
 

--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ async def main():
     # Setup slash command system
     with utils.update_text('Adding slash command extension',
                            'Added slash command extension'):
-        bot.slash = dslash.SlashCommand(bot, sync_commands=True, sync_on_cog_reload=True)
+        bot.slash = dslash.SlashCommand(bot)
 
     # Load extensions
     for i, name in enumerate(cogs, start=1):


### PR DESCRIPTION
Adds a `restart()` method to the bot instance and disables auto-syncing slash commands to prevent being rate limited when frequently restarting.