### PR TITLE
Feature Update 9

### DIFF
--- a/bot/checks.py
+++ b/bot/checks.py
@@ -19,13 +19,32 @@ class UserOnCooldown(commands.CommandError):
 
 
 # Checks
-def is_in_guild(guild_id):
+def used_in_guild(*guild_ids):
+    """Check if a command was used in a given set of guilds."""
     async def predicate(ctx):
+        return ctx.guild and ctx.guild.id in guild_ids
+
+    return commands.check(predicate)
+
+
+def is_in_guild(*guild_ids):
+    """Check if the author is part of a given set of guilds.
+    This will not work without members intent.
+    """
+    async def check_guild(guild_id):
         guild = ctx.bot.get_guild(guild_id)
         if guild is None:
             return False
 
-        return guild.get_member(ctx.author.id) is not None
+        return bool(
+            guild.get_member(ctx.author.id)
+            or await guild.fetch_member(ctx.author.id)
+        )
+        
+    async def predicate(ctx):
+        if ctx.guild and ctx.guild.id in guild_ids:
+            return True
+        return any(await check_guild(n) for n in guild_ids)
 
     return commands.check(predicate)
 

--- a/bot/cogs/administrative.py
+++ b/bot/cogs/administrative.py
@@ -337,6 +337,7 @@ title: The title to show."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
     @client_presence.command(name='playing')
@@ -360,6 +361,7 @@ title: The title to show."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
     @client_presence.command(name='streaming')
@@ -387,6 +389,7 @@ https://www.twitch.tv/thegamecracks ."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
     @client_presence.command(name='listening')
@@ -411,6 +414,7 @@ title: The title to show."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
     @client_presence.command(name='watching')
@@ -435,6 +439,7 @@ title: The title to show."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
     @client_presence.command(name='status')
@@ -456,6 +461,7 @@ This removes any activity the bot currently has."""
         if isinstance(error, commands.BadArgument):
             if 'parse_status' in str(error):
                 await ctx.send('Unknown status given.')
+                ctx.handled = True
 
 
 
@@ -596,8 +602,10 @@ BUG (2020/06/21): An uneven amount of colons will prevent
         if isinstance(error, AttributeError):
             if "'NoneType' object has no attribute" in str(error):
                 await ctx.send('I cannot find the given channel.')
+                ctx.handled = True
         elif isinstance(error, discord.Forbidden):
             await ctx.send('I cannot access this given channel.')
+            ctx.handled = True
 
 
 

--- a/bot/cogs/eh.py
+++ b/bot/cogs/eh.py
@@ -399,8 +399,6 @@ class EventHandlers(commands.Cog):
             await ctx.send(embed=embed, delete_after=min(error.retry_after, 20))
         elif isinstance(error, commands.DisabledCommand):
             await ctx.send('This command is currently disabled.')
-        elif isinstance(error, errors.DollarInputError):
-            await ctx.send(str(error))
         elif isinstance(error, commands.EmojiNotFound):
             await ctx.send(f'I cannot find the given emoji "{error.argument}"')
         elif isinstance(error, commands.ExpectedClosingQuoteError):

--- a/bot/cogs/eh.py
+++ b/bot/cogs/eh.py
@@ -233,7 +233,9 @@ class EventHandlers(commands.Cog):
 
     async def on_command_error(self, ctx, error):
         error_unpacked = getattr(error, 'original', error)
-        if isinstance(error, self.IGNORE_EXCEPTIONS):
+        if getattr(ctx, 'handled', False):
+            return
+        elif isinstance(error, self.IGNORE_EXCEPTIONS):
             return
         elif isinstance(error_unpacked, self.ERRORS_TO_LIMIT):
             if self.command_error_limiter.check_user(ctx, error_unpacked):

--- a/bot/cogs/games.py
+++ b/bot/cogs/games.py
@@ -325,7 +325,6 @@ size: (optional) The size of the deck to use in the session.
 
             if results.done:
                 if size == 2:
-                    await self.bot.dbusers.add_user(ctx.author.id)
                     await self.bot.dbgames.blackjack.change(
                         'played', results.last_player.id, 1)
                     if results.player.maximum == 21:
@@ -364,7 +363,6 @@ size: (optional) The size of the deck to use in the session.
     @commands.cooldown(2, 15, commands.BucketType.user)
     async def client_blackjack_stats(self, ctx):
         """View your blackjack stats."""
-        await self.bot.dbusers.add_user(ctx.author.id)
         row = await self.bot.dbgames.blackjack.get_blackjack_row(ctx.author.id)
         blackjacks = row['blackjacks']
         losses = row['losses']

--- a/bot/cogs/graphing.py
+++ b/bot/cogs/graphing.py
@@ -430,8 +430,8 @@ periods: The number of compounding periods in each term."""
         error = getattr(error, 'original', error)
 
         if isinstance(error, decimal.InvalidOperation):
-            return await ctx.send(
-                'The calculations were too large to handle.')
+            await ctx.send('The calculations were too large to handle.')
+            ctx.handled = True
 
 
 

--- a/bot/cogs/graphing.py
+++ b/bot/cogs/graphing.py
@@ -9,7 +9,6 @@ import decimal
 import functools
 import io
 import itertools
-##import multiprocessing
 from pathlib import Path
 import random
 import string
@@ -26,15 +25,6 @@ import numpy as np
 
 from bot import checks
 from bot import utils
-
-
-##def conn_wrapper(conn, func):
-##    @functools.wraps
-##    def wrapper(*args, **kwargs):
-##        output = func(*args, **kwargs)
-##        conn.send(output)
-##        return output
-##    return wrapper
 
 
 def format_dollars(dollars: decimal.Decimal):
@@ -367,9 +357,7 @@ periods: The number of compounding periods in each term."""
 
         await ctx.trigger_typing()
 
-        loop = asyncio.get_running_loop()
-
-        f, content = await loop.run_in_executor(
+        f, content = await ctx.bot.loop.run_in_executor(
             None, self.interest_stackplot, ctx,
             principal, rate, term, periods
         )
@@ -390,7 +378,6 @@ periods: The number of compounding periods in each term."""
 
 
 
-##    def frequency_analysis(self, conn, ctx, text):
     def frequency_analysis(self, ctx, text):
         """Create a frequency analysis graph of a given text.
 
@@ -454,7 +441,6 @@ periods: The number of compounding periods in each term."""
         f.seek(0)
 
         plt.close(fig)
-##        conn.send(f)
         return f
 
 
@@ -474,21 +460,7 @@ To see the different methods you can use to provide text, check the help message
 
         await ctx.trigger_typing()
 
-        loop = asyncio.get_running_loop()
-##
-##        parent_conn, child_conn = multiprocessing.Pipe()
-##        p = multiprocessing.Process(
-##            target=self.frequency_analysis,
-##            args=(child_conn, ctx, text)
-##        )
-##        p.start()
-##
-##        await loop.run_in_executor(None, p.join)
-##        f = parent_conn.recv()
-##        parent_conn.close()
-##        child_conn.close()
-
-        f = await loop.run_in_executor(
+        f = await ctx.bot.loop.run_in_executor(
             None, self.frequency_analysis, ctx, text)
 
         await ctx.send(file=discord.File(f, 'Frequency Analysis.png'))
@@ -551,13 +523,13 @@ To see the different methods you can use to provide text, check the help message
         # Graph pie
         total_words = sum(words.values())
 
-##        if len(words) > len(top_words):
-##            # Words were left out; add an "other" size
-##            other_count = total_words - sum(count for word, count in top_words)
-##            sizes.append(other_count / total_words)
-##            labels.append(f'Other ({other_count})')
-##            # Use #808080 (grey)
-##            word_colors = np.append(word_colors, [[.5, .5, .5, 1]], 0)
+        # if len(words) > len(top_words):
+        #     # Words were left out; add an "other" size
+        #     other_count = total_words - sum(count for word, count in top_words)
+        #     sizes.append(other_count / total_words)
+        #     labels.append(f'Other ({other_count})')
+        #     # Use #808080 (grey)
+        #     word_colors = np.append(word_colors, [[.5, .5, .5, 1]], 0)
 
         patches, texts, autotexts = ax.pie(
             sizes, labels=labels, colors=word_colors, autopct='%1.2g%%',
@@ -623,9 +595,7 @@ To see the different methods you can use to provide text, check the help message
 
         await ctx.trigger_typing()
 
-        loop = asyncio.get_running_loop()
-
-        f = await loop.run_in_executor(
+        f = await ctx.bot.loop.run_in_executor(
             None, self.word_count_pie, ctx, text)
 
         await ctx.send(file=discord.File(f, 'Word Count Pie Chart.png'))
@@ -715,9 +685,7 @@ To see the different methods you can use to provide text, check the help message
         """Generate a graph with some random data."""
         await ctx.trigger_typing()
 
-        loop = asyncio.get_running_loop()
-
-        f = await loop.run_in_executor(
+        f = await ctx.bot.loop.run_in_executor(
             None, self.test_bar_graphs_3d_image, elevation, azimuth)
 
         await ctx.send(file=discord.File(f, '3D Graph Test.png'))
@@ -789,8 +757,6 @@ To see the different methods you can use to provide text, check the help message
     async def client_test3dgraphanimation(
             self, ctx, frames: int = 30, duration: int = 3):
         """Generate an animating graph with some random data."""
-        loop = asyncio.get_running_loop()
-
         if duration < 1:
             return await ctx.send('Duration must be at least 1 second.')
         if frames < 1:
@@ -803,7 +769,7 @@ To see the different methods you can use to provide text, check the help message
         )
 
         with ctx.typing():
-            fp = await loop.run_in_executor(None, func)
+            fp = await ctx.bot.loop.run_in_executor(None, func)
 
         filesize_limit = (ctx.guild.filesize_limit if ctx.guild is not None
                           else 8_000_000)

--- a/bot/cogs/graphing.py
+++ b/bot/cogs/graphing.py
@@ -355,12 +355,11 @@ periods: The number of compounding periods in each term."""
             return await ctx.send(
                 'The principal/term/periods are too large to calculate.')
 
-        await ctx.trigger_typing()
-
-        f, content = await ctx.bot.loop.run_in_executor(
-            None, self.interest_stackplot, ctx,
-            principal, rate, term, periods
-        )
+        with ctx.typing():
+            f, content = await ctx.bot.loop.run_in_executor(
+                None, self.interest_stackplot, ctx,
+                principal, rate, term, periods
+            )
 
         await ctx.send(
             content, file=discord.File(f, 'Word Count Pie Chart.png'))
@@ -458,10 +457,9 @@ To see the different methods you can use to provide text, check the help message
         if not success:
             return await ctx.send(text)
 
-        await ctx.trigger_typing()
-
-        f = await ctx.bot.loop.run_in_executor(
-            None, self.frequency_analysis, ctx, text)
+        with ctx.typing():
+            f = await ctx.bot.loop.run_in_executor(
+                None, self.frequency_analysis, ctx, text)
 
         await ctx.send(file=discord.File(f, 'Frequency Analysis.png'))
 
@@ -593,10 +591,9 @@ To see the different methods you can use to provide text, check the help message
         if not success:
             return await ctx.send(text)
 
-        await ctx.trigger_typing()
-
-        f = await ctx.bot.loop.run_in_executor(
-            None, self.word_count_pie, ctx, text)
+        with ctx.typing():
+            f = await ctx.bot.loop.run_in_executor(
+                None, self.word_count_pie, ctx, text)
 
         await ctx.send(file=discord.File(f, 'Word Count Pie Chart.png'))
 
@@ -683,10 +680,9 @@ To see the different methods you can use to provide text, check the help message
     async def client_test3dgraph(
             self, ctx, elevation: int = None, azimuth: int = None):
         """Generate a graph with some random data."""
-        await ctx.trigger_typing()
-
-        f = await ctx.bot.loop.run_in_executor(
-            None, self.test_bar_graphs_3d_image, elevation, azimuth)
+        with ctx.typing():
+            f = await ctx.bot.loop.run_in_executor(
+                None, self.test_bar_graphs_3d_image, elevation, azimuth)
 
         await ctx.send(file=discord.File(f, '3D Graph Test.png'))
 

--- a/bot/cogs/guildirish.py
+++ b/bot/cogs/guildirish.py
@@ -64,8 +64,6 @@ class IrishSquad(commands.Cog):
 
         db = self.bot.dbirish.charges
 
-        await ctx.channel.trigger_typing()
-
         await db.change_charges(ctx.author.id, number)
         new_charges = await db.get_charges(ctx.author.id)
 
@@ -90,8 +88,6 @@ class IrishSquad(commands.Cog):
             return await ctx.send('You must remove at least one charge.')
 
         db = self.bot.dbirish.charges
-
-        await ctx.channel.trigger_typing()
 
         charges = await db.get_charges(ctx.author.id)
         new_charges = charges - number
@@ -122,7 +118,6 @@ class IrishSquad(commands.Cog):
     async def client_charges_number(self, ctx, *, user: discord.User = None):
         """Show the number of charges you or someone else has."""
         db = self.bot.dbirish.charges
-        await ctx.channel.trigger_typing()
 
         if user is None:
             user = ctx.author
@@ -153,7 +148,6 @@ class IrishSquad(commands.Cog):
     async def client_charges_guildtotal(self, ctx):
         """Show the squad's total charges."""
         db = self.bot.dbirish.charges
-        await ctx.channel.trigger_typing()
 
         async with await db.connect() as conn:
             async with conn.cursor(transaction=True) as c:
@@ -207,9 +201,8 @@ This requires a confirmation."""
 
         if confirmed:
             db = ctx.bot.dbirish.charges
-            async with await db.connect()(writing=True) as conn:
+            async with await db.connect(writing=True) as conn:
                 await conn.execute(f'DELETE FROM {db.TABLE_NAME}')
-                await conn.commit()
 
             await prompt.update('Completed charge wipe!',
                                 prompt.emoji_yes.color)
@@ -243,7 +236,7 @@ This requires a confirmation."""
 
         invalid_users = []
 
-        async with await db.connect()(writing=True) as conn:
+        async with await db.connect(writing=True) as conn:
             async with await conn.execute('SELECT id FROM Users') as c:
                 # Remove all IDs from the Users table if they are
                 # not in the guild
@@ -263,7 +256,6 @@ This requires a confirmation."""
                     ', '.join([str(user_id) for user_id in invalid_users])
                 )
                 await conn.execute(query)
-                await conn.commit()
 
         # Execute vacuum
         await db.vacuum()

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -1,0 +1,275 @@
+import asyncio
+import datetime
+
+import discord
+from discord.ext import commands, tasks
+
+import abattlemetrics as abm
+
+
+class SignalHill(commands.Cog):
+    """Commands to be used in moderation."""
+
+    ACTIVE_HOURS = range(6, 22)
+    BM_SERVER_LINK = 'https://www.battlemetrics.com/servers/{game}/{server_id}'
+    INA_SERVER_ID = 10654566
+    INA_STATUS_MESSAGE_ID = (819632332896993360, 842228691077431296)
+    INA_STATUS_SECONDS = 60
+    INA_STATUS_EDIT_RATE = 10
+    REFRESH_EMOJI = '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}'
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.bm_client = abm.BattleMetricsClient(self.bot.session)
+        self.ina_status_enabled = True
+        self.ina_status_last = None
+        self.ina_status_cooldown = commands.CooldownMapping.from_cooldown(
+            1, self.INA_STATUS_EDIT_RATE, commands.BucketType.default)
+        self.ina_status_loop.start()
+
+
+    def cog_unload(self):
+        self.ina_status_loop.cancel()
+
+
+    @property
+    def partial_ina_status(self) -> discord.PartialMessage:
+        """Return a PartialMessage displaying the I&A status."""
+        ch, ms = self.INA_STATUS_MESSAGE_ID
+        return self.bot.get_channel(ch).get_partial_message(ms)
+
+
+    @staticmethod
+    def ina_status_should_update(old, new):
+        """Compare particular attributes of two Server objects to see
+        if the status should be updated."""
+        def player_set(s):
+            return set((p.id, p.playtime) for p in s.players)
+
+        attrs = ('player_count', 'status', 'max_players', 'name')
+
+        # Check uptime, do not update if old and new are both offline
+        if new.status != 'online' and old.status != 'online':
+            return False
+
+        # Check basic attributes
+        if any(getattr(old, a) != getattr(new, a) for a in attrs):
+            return True
+
+        # Check players
+        return player_set(old) != player_set(new)
+
+
+    def ina_status_create_embed(self, server: abm.Server):
+        """Create the embed for updating the I&A status.
+
+        Returns:
+            discord.Embed
+
+        """
+        now = datetime.datetime.now().astimezone()
+
+        embed = discord.Embed(
+            title=server.name,
+            timestamp=datetime.datetime.utcnow()
+        ).set_footer(
+            text='Last updated'
+        )
+
+        description = []
+
+        maybe_offline = (
+            '(If I am offline, scroll up or check [battlemetrics]({link}))')
+        if not now.hour in self.ACTIVE_HOURS:
+            maybe_offline = (
+                "(I may be offline at this time, if so you can "
+                'scroll up or check [battlemetrics]({link}))'
+            )
+        maybe_offline = maybe_offline.format(
+            link=self.BM_SERVER_LINK
+        ).format(
+            game='arma3', server_id=self.INA_SERVER_ID
+        )
+
+        description.append(maybe_offline)
+
+        if server.status != 'online':
+            description.append('Server is offline')
+            embed.description = '\n'.join(description)
+            return server, embed
+ 
+        description.append('Map: ' + server.details['map'])
+        description.append('Player Count: {0.player_count}/{0.max_players}'.format(server))
+        # Generate list of player names with their playtime
+        players = sorted(
+            server.players, reverse=True, key=lambda p: p.playtime or 0)
+        for i, p in enumerate(players):
+            name = discord.utils.escape_markdown(p.name)
+            if p.first_time:
+                name = f'__{name}__'
+            pt = ''
+            # if p.playtime:
+            #     minutes, seconds = divmod(int(p.playtime), 60)
+            #     hours, minutes = divmod(minutes, 60)
+            #     pt = f' ({hours}:{minutes:02d}h)'
+            score = f' ({p.score})' if p.score is not None else ''
+            players[i] = f'{name}{pt}{score}'
+        if players:
+            # Group them into 1-3 fields in sizes of 5
+            n_fields = min((len(players) + 4) // 5, 3)
+            size = -(len(players) // -n_fields)  # ceil division
+            fields = [players[i:i + size] for i in range(0, len(players), size)]
+            for i, p_list in enumerate(fields):
+                value = '\n'.join(p_list)
+                name = '\u200b' if i else 'Name (Score)'
+                embed.add_field(name=name, value=value)
+
+        embed.description = '\n'.join(description)
+
+        return embed
+
+
+    async def ina_status_update(self):
+        """Update the I&A status message.
+
+        Returns:
+            Tuple[abattlemetrics.Server, discord.Embed]:
+                The server fetched from the API and the embed generated
+                from it.
+            Tuple[None, None]: On cooldown.
+
+        """
+        if self.ina_status_cooldown.update_rate_limit(None):
+            return None, None
+        # NOTE: a high cooldown period will help with preventing concurrent
+        # updates but this by itself does not remove the potential
+
+        message = self.partial_ina_status
+
+        server = await self.bm_client.get_server_info(
+            self.INA_SERVER_ID, include_players=True)
+
+        old, self.ina_status_last = self.ina_status_last, server
+        # if (    not skip_content_check
+        #         and old is not None
+        #         and not self.ina_status_should_update(old, server)):
+        #     return None, None
+
+        embed = self.ina_status_create_embed(server)
+        await message.edit(embed=embed)
+
+        return server, embed
+
+
+    def get_next_period(self, interval: int, now=None,
+                        *, inclusive=False) -> int:
+        """Get the number of seconds to sleep to reach the next period
+        given the current time.
+
+        For example, if the interval was 600s and the
+        current time was X:09:12, this would return 48s.
+
+        Args:
+            interval (int): The interval per hour in seconds.
+            now (Optional[datetime.datetime]): The current time.
+                Defaults to datetime.datetime.utcnow().
+            inclusive (bool): If True and the current time is already
+                in sync with the interval, this returns 0.
+
+        Returns:
+            int
+
+        """
+        now = now or datetime.datetime.utcnow()
+        seconds = now.minute * 60 + now.second
+        wait_for = interval - seconds % interval
+        if inclusive:
+            wait_for %= interval
+        return wait_for
+
+
+    @commands.Cog.listener('on_raw_reaction_add')
+    async def ina_status_react(self, payload):
+        """Update the I&A status manually with a reaction."""
+        ch, msg = self.INA_STATUS_MESSAGE_ID
+        if (    self.ina_status_enabled
+                and payload.channel_id != ch or payload.message_id != msg
+                or payload.emoji.name != self.REFRESH_EMOJI
+                or payload.member and payload.member.bot):
+            return
+
+        server, embed = await self.ina_status_update()
+        # NOTE: loop could decide to update right after this
+
+        if server is not None:
+            # Update was successful; remove reaction
+            message = self.partial_ina_status
+            try:
+                await message.clear_reaction(self.REFRESH_EMOJI)
+            except discord.HTTPException:
+                pass
+            else:
+                await message.add_reaction(self.REFRESH_EMOJI)
+
+
+    @tasks.loop()
+    async def ina_status_loop(self):
+        """Update the I&A status periodically."""
+        server, embed = await self.ina_status_update()
+
+        next_period = 15
+        if server is None or server.status == 'online':
+            next_period = self.get_next_period(self.INA_STATUS_SECONDS)
+        await asyncio.sleep(next_period)
+
+
+    @ina_status_loop.before_loop
+    async def before_ina_status_loop(self):
+        await self.bot.wait_until_ready()
+
+        # Sync to the next interval
+        next_period = self.get_next_period(
+            self.INA_STATUS_SECONDS, inclusive=True)
+        await asyncio.sleep(next_period)
+
+
+    def ina_status_toggle(self) -> bool:
+        """Toggle the I&A status loop and react listener."""
+        self.ina_status_enabled = not self.ina_status_enabled
+        self.ina_status_loop.cancel()
+        if self.ina_status_enabled:
+            self.ina_status_loop.start()
+        return self.ina_status_enabled
+
+
+    @commands.Cog.listener('on_connect')
+    async def ina_status_toggle_on_connect(self):
+        """Turn on the I&A status loop and react listener after connecting."""
+        if not self.ina_status_enabled:
+            self.ina_status_toggle()
+
+
+
+
+
+
+    @commands.command(name='togglesignalstatus', aliases=('tss',))
+    @commands.is_owner()
+    async def client_toggle_ina_status(self, ctx):
+        """Toggle the Signal Hill I&A status message.
+Turns back on when the bot connects."""
+        enabled = self.ina_status_toggle()
+        emoji = '\N{LARGE GREEN CIRCLE}' if enabled else '\N{LARGE RED CIRCLE}'
+        await ctx.message.add_reaction(emoji)
+
+
+
+
+
+
+
+
+
+
+def setup(bot):
+    bot.add_cog(SignalHill(bot))

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -1,12 +1,21 @@
 import asyncio
 import datetime
+import io
+import itertools
 import logging
+import math
 from typing import Optional
 
+import abattlemetrics as abm
 import discord
 from discord.ext import commands, tasks
+from matplotlib import dates as mdates
+import matplotlib.pyplot as plt
+from matplotlib import ticker
+import numpy as np
+from scipy.interpolate import make_interp_spline
 
-import abattlemetrics as abm
+from bot import utils
 
 abm_log = logging.getLogger('abattlemetrics')
 abm_log.setLevel(logging.INFO)
@@ -19,7 +28,7 @@ if not abm_log.hasHandlers():
 
 
 class SignalHill(commands.Cog):
-    """Commands to be used in moderation."""
+    """Stuff for the Signal Hill server."""
 
     ACTIVE_HOURS = range(6, 22)
     BM_SERVER_LINK = 'https://www.battlemetrics.com/servers/{game}/{server_id}'
@@ -27,6 +36,8 @@ class SignalHill(commands.Cog):
     INA_STATUS_MESSAGE_ID = (819632332896993360, 842228691077431296)
     INA_STATUS_SECONDS = 60
     INA_STATUS_EDIT_RATE = 10
+    INA_STATUS_GRAPH_DEST = 842924251954151464
+    INA_STATUS_GRAPH_RATE = 60 * 30
     REFRESH_EMOJI = '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}'
 
     def __init__(self, bot):
@@ -34,8 +45,11 @@ class SignalHill(commands.Cog):
         self.bm_client = abm.BattleMetricsClient(self.bot.session)
         self.ina_status_enabled = True
         self.ina_status_last = None
-        self.ina_status_cooldown = commands.CooldownMapping.from_cooldown(
+        self.ina_status_cooldown = commands.Cooldown(
             1, self.INA_STATUS_EDIT_RATE, commands.BucketType.default)
+        self.ina_status_graph_last = None
+        self.ina_status_graph_cooldown = commands.Cooldown(
+            1, self.INA_STATUS_GRAPH_RATE, commands.BucketType.default)
         self.ina_status_loop.start()
 
 
@@ -71,6 +85,24 @@ class SignalHill(commands.Cog):
 
         # Check players
         return player_set(old) != player_set(new)
+
+
+    async def ina_status_fetch_server(self, *args, **kwargs):
+        """Fetch the I&A server and replace self.ina_status_last.
+
+        Args:
+            *args
+            **kwargs: Parameters to pass into get_server_info().
+
+        Returns:
+            Tuple[abattlemetrics.Server, Optional[abattlemetrics.Server]]:
+                The server that was fetched and the previous value
+                or self.ina_status_last.
+
+        """
+        server = await self.bm_client.get_server_info(*args, **kwargs)
+        old, self.ina_status_last = self.ina_status_last, server
+        return server, old
 
 
     def ina_status_create_embed(self, server: abm.Server):
@@ -142,6 +174,37 @@ class SignalHill(commands.Cog):
         return embed
 
 
+    async def ina_status_upload_graph(self, server, graphing_cog):
+        """Generate the player count graph, upload it, and cache
+        the resulting attachment in self.ina_status_graph_last.
+
+        Args:
+            server (abattlemetrics.Server): The Server object.
+                Used to know the max number of players.
+            graphing_cog (commands.Cog): The Graphing cog.
+
+        Returns:
+            discord.Attachment
+
+        """
+        stop = datetime.datetime.utcnow()
+        start = stop - datetime.timedelta(hours=24)
+        datapoints = await self.bm_client.get_player_count_history(
+            self.INA_SERVER_ID, start=start, stop=stop
+        )
+
+        f = await self.bot.loop.run_in_executor(
+            None, self.ina_status_player_count_graph,
+            datapoints, server, graphing_cog
+        )
+        graph = discord.File(f, filename='graph.png')
+
+        m = await self.bot.get_channel(self.INA_STATUS_GRAPH_DEST).send(file=graph)
+        a = m.attachments[0]
+        self.ina_status_graph_last = a
+        return a
+
+
     async def ina_status_update(self):
         """Update the I&A status message.
 
@@ -159,18 +222,22 @@ class SignalHill(commands.Cog):
 
         message = self.partial_ina_status
 
-        server = await self.bm_client.get_server_info(
+        server, old = await self.ina_status_fetch_server(
             self.INA_SERVER_ID, include_players=True)
 
-        old, self.ina_status_last = self.ina_status_last, server
-        # if (    not skip_content_check
-        #         and old is not None
-        #         and not self.ina_status_should_update(old, server)):
-        #     return None, None
-
         embed = self.ina_status_create_embed(server)
-        await message.edit(embed=embed)
 
+        attachment = self.ina_status_graph_last
+        if not self.ina_status_graph_cooldown.update_rate_limit(None):
+            graphing_cog = self.bot.get_cog('Graphing')
+            if graphing_cog:
+                attachment = await self.ina_status_upload_graph(
+                    server, graphing_cog)
+
+        if attachment:
+            embed.set_image(url=attachment)
+
+        await message.edit(embed=embed)
         return server, embed
 
 
@@ -274,6 +341,110 @@ Turns back on when the bot connects."""
         enabled = self.ina_status_toggle()
         emoji = '\N{LARGE GREEN CIRCLE}' if enabled else '\N{LARGE RED CIRCLE}'
         await ctx.message.add_reaction(emoji)
+
+
+    def ina_status_player_count_graph(self, datapoints, server, graphing_cog):
+        """Generate a player count history graph.
+
+        Args:
+            datapoints (List[abattlemetrics.DataPoint])
+            server (abattlemetrics.Server): The Server object.
+                Used for determining the y-axis limits.
+            graphing_cog (commands.Cog):  The Graphing cog.
+
+        Returns:
+            io.BytesIO
+
+        """
+        def format_hour(x, pos):
+            return mdates.num2date(x).strftime('%I %p').lstrip('0')
+
+        line_color = '#F54F33'
+        fig, ax = plt.subplots()
+
+        if any(None not in (d.min, d.max) for d in datapoints):
+            # Resolution is not raw; generate bar graph with error bars
+            pass
+
+        # Plot player counts
+        x, y = zip(*((d.timestamp, d.value) for d in datapoints))
+        # Generate smoother curve with 300 points
+        x = np.array([mdates.date2num(dt) for dt in x])
+        x_min, x_max = x.min(), x.max()
+        n_points = 300
+        spl = make_interp_spline(x, y, k=2)
+        x_new = np.linspace(x_min, x_max, n_points)
+        y_smooth = spl(x_new)
+        # # Estimate where the actual datapoints are to mark them
+        # x_to_marker_ratio = (n_points - 1) / (x_max - x_min)
+        # markers = [int((n - x_min) * x_to_marker_ratio) for n in x]
+        lines = ax.plot_date(x_new, y_smooth, line_color)  # , marker='.', markevery=markers)
+
+        # Set limits and fill under the line
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(0, server.max_players)
+        ax.fill_between(x_new, y_smooth, color=line_color + '55')
+
+        # Set xticks to every two hours
+        step = 1 / 12
+        start = x_max - step + (mdates.date2num(datetime.datetime.utcnow()) - x_max)
+        ax.set_xticks(np.arange(start, x_min, -step))
+        ax.xaxis.set_major_formatter(format_hour)
+        ax.set_xlabel('UTC', loc='left', color=line_color)
+
+        # Set yticks
+        ax.yaxis.set_major_locator(ticker.MultipleLocator(5))
+
+        # Add grid
+        ax.set_axisbelow(True)
+        ax.grid(color='#707070', alpha=0.4)
+
+        # Color the ticks and make spine invisible
+        for spine in ax.spines.values():
+            spine.set_color('#00000000')
+        ax.tick_params(labelsize=9, color='#70707066', labelcolor=line_color)
+
+        # Make background fully transparent
+        fig.patch.set_facecolor('#00000000')
+
+        graphing_cog.set_axes_aspect(ax, 9 / 16, 'box')
+
+        f = io.BytesIO()
+        fig.savefig(f, format='png', bbox_inches='tight', pad_inches=0,
+                    dpi=80)
+        # bbox_inches, pad_inches: removes padding around the graph
+        f.seek(0)
+
+        plt.close(fig)
+        return f
+
+
+
+
+
+    @commands.command(name='history')
+    @commands.is_owner()
+    async def client_player_count_history(self, ctx):
+        """Render the player count history graph."""
+        stop = datetime.datetime.utcnow()
+        start = stop - datetime.timedelta(hours=24)
+        datapoints = await self.bm_client.get_player_count_history(
+            self.INA_SERVER_ID, start=start, stop=stop
+        )
+
+        graphing_cog = ctx.bot.get_cog('Graphing')
+        server = self.ina_status_last
+        if not server:
+            server, old = await self.ina_status_fetch_server(self.INA_SERVER_ID)
+
+        f = await ctx.bot.loop.run_in_executor(
+            None, self.ina_status_player_count_graph,
+            datapoints, server, graphing_cog
+        )
+        embed = discord.Embed().set_image(url='attachment://graph.png')
+        graph = discord.File(f, filename='graph.png')
+
+        await ctx.send(embed=embed, file=graph)
 
 
 

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -1,10 +1,21 @@
 import asyncio
 import datetime
+import logging
+from typing import Optional
 
 import discord
 from discord.ext import commands, tasks
 
 import abattlemetrics as abm
+
+abm_log = logging.getLogger('abattlemetrics')
+abm_log.setLevel(logging.INFO)
+if not abm_log.hasHandlers():
+    handler = logging.FileHandler(
+        'abattlemetrics.log', encoding='utf-8', mode='w')
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+    abm_log.addHandler(handler)
 
 
 class SignalHill(commands.Cog):
@@ -33,10 +44,12 @@ class SignalHill(commands.Cog):
 
 
     @property
-    def partial_ina_status(self) -> discord.PartialMessage:
+    def partial_ina_status(self) -> Optional[discord.PartialMessage]:
         """Return a PartialMessage displaying the I&A status."""
-        ch, ms = self.INA_STATUS_MESSAGE_ID
-        return self.bot.get_channel(ch).get_partial_message(ms)
+        channel_id, message_id = self.INA_STATUS_MESSAGE_ID
+        channel = self.bot.get_channel(channel_id)
+        if channel:
+            return channel.get_partial_message(message_id)
 
 
     @staticmethod

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -146,7 +146,9 @@ class SignalHill(commands.Cog):
             description.append('Server is offline')
             embed.description = '\n'.join(description)
             return embed
- 
+
+        embed.set_author(name=f'Rank #{server.rank:,}')
+
         description.append('Map: ' + server.details['map'])
         description.append('Player Count: {0.player_count}/{0.max_players}'.format(server))
         # Generate list of player names with their playtime

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -18,7 +18,7 @@ from scipy.interpolate import make_interp_spline
 from bot import utils
 
 abm_log = logging.getLogger('abattlemetrics')
-abm_log.setLevel(logging.INFO)
+abm_log.setLevel(logging.DEBUG)
 if not abm_log.hasHandlers():
     handler = logging.FileHandler(
         'abattlemetrics.log', encoding='utf-8', mode='w')
@@ -278,10 +278,10 @@ class SignalHill(commands.Cog):
     async def ina_status_react(self, payload):
         """Update the I&A status manually with a reaction."""
         ch, msg = self.INA_STATUS_MESSAGE_ID
-        if (    self.ina_status_enabled
-                and payload.channel_id != ch or payload.message_id != msg
+        if (    not self.ina_status_enabled
+                or payload.channel_id != ch or payload.message_id != msg
                 or payload.emoji.name != self.REFRESH_EMOJI
-                or payload.member and payload.member.bot):
+                or getattr(payload.member, 'bot', False)):
             return
 
         server, embed = await self.ina_status_update()

--- a/bot/cogs/guildsignal.py
+++ b/bot/cogs/guildsignal.py
@@ -145,7 +145,7 @@ class SignalHill(commands.Cog):
         if server.status != 'online':
             description.append('Server is offline')
             embed.description = '\n'.join(description)
-            return server, embed
+            return embed
  
         description.append('Map: ' + server.details['map'])
         description.append('Player Count: {0.player_count}/{0.max_players}'.format(server))

--- a/bot/cogs/helpcommand.py
+++ b/bot/cogs/helpcommand.py
@@ -22,7 +22,7 @@ class HelpCommand(commands.HelpCommand):
 
     help_cog_commands_per_page = 9  # Max of 25 fields
 
-    help_message_length_threshold = 300
+    help_message_length_threshold = 500
     # Maximum allowed characters in a help message before it is sent via DM
 
     no_category = 'No Category'

--- a/bot/cogs/helpcommand.py
+++ b/bot/cogs/helpcommand.py
@@ -30,9 +30,7 @@ class HelpCommand(commands.HelpCommand):
     def __init__(self):
         super().__init__(
             command_attrs={
-                # This is the command.help string
                 'help': 'Shows help about the bot, a command, or a category',
-                # this is a custom attribute passed to the help command
                 'cooldown': commands.Cooldown(2, 3, commands.BucketType.user)
             }
         )

--- a/bot/cogs/images.py
+++ b/bot/cogs/images.py
@@ -109,8 +109,6 @@ class Images(commands.Cog):
                 'Sorry, but the bot currently cannot query for a cat image.')
             return await asyncio.sleep(10)
 
-        await ctx.trigger_typing()
-
         try:
             cat = await query_thatapiguy(
                 ctx.bot.session, CAT_API_URL, CAT_API_KEY)
@@ -133,8 +131,6 @@ class Images(commands.Cog):
             await ctx.send(
                 'Sorry, but the bot currently cannot query for a dog image.')
             return await asyncio.sleep(10)
-
-        await ctx.trigger_typing()
 
         try:
             dog = await query_thatapiguy(
@@ -170,8 +166,6 @@ If not given, defaults to Level M.
 text: The message to encode."""
         if ec_level is None:
             ec_level = QRCodeECL.M
-
-        await ctx.trigger_typing()
 
         qr = qrcode.QRCode(
             version=version,
@@ -287,8 +281,6 @@ Credits to Leona Sky for the free font: https://www.dafont.com/among-us.font"""
                 "Your text is {s} plural('line', {s}) too long.".format(
                     s=size)
             ))
-
-        await ctx.trigger_typing()
 
         f = await ctx.bot.loop.run_in_executor(
             None, self.write_amongustext, ctx,

--- a/bot/cogs/images.py
+++ b/bot/cogs/images.py
@@ -186,8 +186,7 @@ text: The message to encode."""
                 s += ' Try lowering the error correction level.'
             return await ctx.send(s)
 
-        loop = asyncio.get_running_loop()
-        img = await loop.run_in_executor(None, qr.make_image)
+        img = await ctx.bot.loop.run_in_executor(None, qr.make_image)
 
         f = io.BytesIO()
         img.save(f, format='png')
@@ -291,9 +290,7 @@ Credits to Leona Sky for the free font: https://www.dafont.com/among-us.font"""
 
         await ctx.trigger_typing()
 
-        loop = asyncio.get_running_loop()
-
-        f = await loop.run_in_executor(
+        f = await ctx.bot.loop.run_in_executor(
             None, self.write_amongustext, ctx,
             text, transparent
         )

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -762,7 +762,7 @@ Format referenced from the Ayana bot."""
 
         # Extract attributes based on whether its a Member or User
         if isinstance(user, discord.Member):
-            description = None
+            description = ''
             activity = user.activity
             # If presences or members intent are disabled, d.py returns
             # None for activity
@@ -771,7 +771,7 @@ Format referenced from the Ayana bot."""
                 utils.timedelta_string(
                     relativedelta(
                         datetime.datetime.utcnow(),
-                        user.created_at
+                        user.joined_at
                     ),
                     **self.DATETIME_DIFFERENCE_PRECISION,
                     inflector=ctx.bot.inflector
@@ -796,8 +796,7 @@ Format referenced from the Ayana bot."""
                 if status == 'Dnd':
                     status = 'Do Not Disturb'
         else:
-            description = '*For more information, ' \
-                          'use this command in a server.*'
+            description = '*For more information, use this command in a server.*'
             activity = None
             guild = None
             joined = None

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -103,8 +103,7 @@ Optional settings:
 
         start_time = datetime.datetime.fromtimestamp(
             self.process.create_time()).astimezone()
-        start_time = await ctx.bot.localize_datetime(ctx.author.id, start_time)
-        start_time = utils.strftime_zone(start_time)
+        start_time = await ctx.bot.strftime_user(ctx.author.id, start_time)
 
         field_statistics = [
             f"Bot started at: {start_time}"
@@ -632,10 +631,7 @@ Format referenced from the Ayana bot."""
                 **self.DATETIME_DIFFERENCE_PRECISION,
                 inflector=ctx.bot.inflector
             ),
-            utils.strftime_zone(
-                await ctx.bot.localize_datetime(
-                    ctx.author.id, guild.created_at)
-            )
+            await ctx.bot.strftime_user(ctx.author.id, guild.created_at)
         )
         count_text_ch = len(guild.text_channels)
         count_voice_ch = len(guild.voice_channels)
@@ -712,9 +708,8 @@ Format referenced from the Ayana bot."""
         )
         diff_string = utils.timedelta_string(diff, inflector=ctx.bot.inflector)
 
-        uptime = await ctx.bot.localize_datetime(
+        uptime_string = await ctx.bot.strftime_user(
             ctx.author.id, ctx.bot.uptime_last_connect)
-        uptime_string = utils.strftime_zone(uptime)
 
         await ctx.send(embed=discord.Embed(
             title='Uptime',
@@ -781,10 +776,7 @@ Format referenced from the Ayana bot."""
                     **self.DATETIME_DIFFERENCE_PRECISION,
                     inflector=ctx.bot.inflector
                 ),
-                utils.strftime_zone(
-                    await ctx.bot.localize_datetime(
-                        ctx.author.id, user.joined_at)
-                )
+                await ctx.bot.strftime_user(ctx.author.id, user.joined_at)
             )
             nickname = user.nick
             roles = user.roles
@@ -824,10 +816,7 @@ Format referenced from the Ayana bot."""
                 **self.DATETIME_DIFFERENCE_PRECISION,
                 inflector=ctx.bot.inflector
             ),
-            utils.strftime_zone(
-                await ctx.bot.localize_datetime(
-                    ctx.author.id, user.created_at)
-            )
+            await ctx.bot.strftime_user(ctx.author.id, user.created_at)
         )
 
         embed = discord.Embed(

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -476,7 +476,7 @@ cumulative: If true, makes the number of messages cumulative when graphing."""
                         'WHERE guild_id = ? AND created_at > ?',
                         ctx.guild.id, yesterday) as c:
                     while m := await c.fetchone():
-                        dt = datetime.datetime.fromisoformat(m['created_at'])
+                        dt = m['created_at']
                         td = max(0, utcnow_timestamp - dt.timestamp())
                         messages.append(td)
             count = len(messages)

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -81,8 +81,11 @@ Optional settings:
     -S --system: show system-related information about the bot."""
         embed = discord.Embed(
             title='About',
-            description=('I do random stuff, whatever <@153551102443257856> '
-                         'adds to me'),
+            description=(
+                'I do random stuff, whatever '
+                '[thegamecracks](https://github.com/thegamecracks/thegamebot) '
+                'adds to me.'
+            ),
             color=utils.get_bot_color(ctx.bot)
         ).set_thumbnail(
             url=self.bot.user.avatar_url

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -87,7 +87,7 @@ Optional settings:
             title='About',
             description=(
                 'I do random stuff, whatever '
-                '[thegamecracks](https://github.com/thegamecracks/thegamebot) '
+                '[**thegamecracks**](https://github.com/thegamecracks/thegamebot) '
                 'adds to me.'
             ),
             color=utils.get_bot_color(ctx.bot)

--- a/bot/cogs/info.py
+++ b/bot/cogs/info.py
@@ -52,7 +52,7 @@ class Informative(commands.Cog):
 
     MESSAGECOUNT_BINS_PER_HOUR = 3
     MESSAGECOUNT_DOWNTIME_BINS_PER_HOUR = 6
-    MESSAGECOUNT_IGNORE_ALLOWED_DOWNTIMES = False
+    MESSAGECOUNT_IGNORE_ALLOWED_DOWNTIMES = True
     # If true, uses the uptime cog to filter downtimes
     # shorter than UPTIME_ALLOWED_DOWNTIME
 

--- a/bot/cogs/mathematics.py
+++ b/bot/cogs/mathematics.py
@@ -34,10 +34,16 @@ class Mathematics(commands.Cog):
 
     async def cog_command_error(self, ctx, error):
         error = getattr(error, 'original', error)
-        if isinstance(error, OverflowError):
+        handled = True
+        if getattr(ctx, 'handled', False):
+            return
+        elif isinstance(error, OverflowError):
             await ctx.send(error.args[1] + '.')
         elif isinstance(error, ZeroDivisionError):
             await ctx.send('Division by Zero occurred.')
+        else:
+            handled = False
+        ctx.handled = handled
 
 
 
@@ -174,6 +180,7 @@ To reveal the evaluation of your expression, add --debug to your expression."""
     @client_evaluate.error
     async def client_evaluate_error(self, ctx, error):
         error = getattr(error, 'original', error)
+        handled = True
         if isinstance(error, SyntaxError):
             await ctx.send(f'Undefined Syntax Error occurred: {error}')
         elif isinstance(error, ValueError):
@@ -182,6 +189,9 @@ To reveal the evaluation of your expression, add --debug to your expression."""
             await ctx.send(str(error))
         elif isinstance(error, decimal.Overflow):
             await ctx.send('Could not calculate due to overflow.')
+        else:
+            handled = False
+        ctx.handled = handled
 
 
 
@@ -249,6 +259,7 @@ m: Second number. If this is provided, returns n to m fibonacci numbers."""
         error = getattr(error, 'original', error)
         if isinstance(error, ValueError):
             await ctx.send(str(error))
+            ctx.handled = True
 
 
 
@@ -382,10 +393,14 @@ The maximum number to check factors is 10000."""
     @client_factors.error
     async def client_factors_error(self, ctx, error):
         error = getattr(error, 'original', error)
+        handled = True
         if isinstance(error, ValueError):
             await ctx.send(str(error))
         elif isinstance(error, TypeError):
             await ctx.send(str(error))
+        else:
+            handled = False
+        ctx.handled = handled
 
 
 
@@ -503,6 +518,7 @@ n: The number to convert."""
     @client_numberbase.error
     async def client_numberbase_error(self, ctx, error):
         error = getattr(error, 'original', error)
+        handled = True
         if isinstance(error, ValueError):
             msg = str(error)
             if msg == 'substring not found':
@@ -516,6 +532,9 @@ n: The number to convert."""
             await ctx.send(msg)
         elif isinstance(error, TypeError):
             await ctx.send(str(error))
+        else:
+            handled = False
+        ctx.handled = handled
 
 
 

--- a/bot/cogs/mathematics.py
+++ b/bot/cogs/mathematics.py
@@ -264,8 +264,6 @@ m: Second number. If this is provided, returns n to m fibonacci numbers."""
 
 If y is "low", calculates the lowest divisor of x other than itself.
 If y is "high", calculates the highest divisor of x other than itself."""
-        await ctx.channel.trigger_typing()
-
         if x > 1_000_000:
             await ctx.send('X must be below one million.')
         elif y == 'low' or y == 'high':
@@ -294,8 +292,6 @@ If y is "high", calculates the highest divisor of x other than itself."""
 n - The number to test.
 setting - low or high: Returns either the lowest or highest divisor
  other than 1 and itself."""
-        await ctx.channel.trigger_typing()
-
         if n < 2:
             return await ctx.send(f'{n} is not a prime number;\n'
                                   'all whole numbers below 3 are not prime.')
@@ -373,8 +369,6 @@ n - The number to test.
 The maximum number to check factors is 10000."""
         if n > 10000:
             return await ctx.send('N must be below ten thousand.')
-
-        await ctx.channel.trigger_typing()
 
         factors = self.factors(n)
 

--- a/bot/cogs/messagetracker.py
+++ b/bot/cogs/messagetracker.py
@@ -36,8 +36,7 @@ class MessageTracker(commands.Cog):
         """Cancel running tasks and close the database."""
         self.vacuum.cancel()
         if self._conn:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._conn.close())
+            self.bot.loop.create_task(self._conn.close())
 
     @commands.Cog.listener()
     async def on_message(self, m):

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -52,6 +52,7 @@ class Moderation(commands.Cog):
 
     @commands.group(name='purge', invoke_without_command=True)
     @commands.cooldown(2, 10, commands.BucketType.channel)
+    @commands.guild_only()
     @commands.has_permissions(manage_messages=True)
     @commands.bot_has_permissions(
         manage_messages=True,
@@ -67,6 +68,7 @@ limit: The number of messages to look through. (range: 2-100)"""
 
     @client_purge.command(name='bot')
     @commands.cooldown(2, 10, commands.BucketType.channel)
+    @commands.guild_only()
     @commands.has_permissions(manage_messages=True)
     @commands.bot_has_permissions(
         manage_messages=True,
@@ -85,7 +87,11 @@ limit: The number of messages to look through. (range: 2-100)"""
 
     @client_purge.command(name='self')
     @commands.cooldown(2, 10, commands.BucketType.channel)
-    @commands.has_permissions(manage_messages=True)
+    @commands.guild_only()
+    @commands.check_any(
+        commands.has_permissions(manage_messages=True),
+        commands.is_owner()
+    )
     @commands.bot_has_permissions(read_message_history=True)
     async def client_purge_self(self, ctx, limit: PurgeLimitConverter):
         """Delete messages from me.

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -104,11 +104,14 @@ limit: The number of messages to look through. (range: 2-100)"""
     @commands.bot_has_permissions(read_message_history=True)
     async def client_purge_self(self, ctx, limit: PurgeLimitConverter):
         """Delete messages from me.
-This will also remove messages that appear to be invoking one of my commands.
+This will also remove messages that appear to be invoking one of my commands if I have Manage Messages permission.
 
 limit: The number of messages to look through. (range: 2-100)"""
         def check(m):
-            return m.author == ctx.me or m.content.startswith(prefixes)
+            return (
+                m.author == ctx.me
+                or perms.manage_messages and m.content.startswith(prefixes)
+            )
 
         perms = ctx.me.permissions_in(ctx.channel)
         prefixes = ()

--- a/bot/cogs/notes.py
+++ b/bot/cogs/notes.py
@@ -124,7 +124,6 @@ The index parameter allows several formats:
 3-8  # show notes 3 through 8
 If nothing is provided, all notes are shown."""
         index: Optional[Iterable[int]]
-        await ctx.channel.trigger_typing()
 
         note_list = await self.get_notes(ctx.author.id)
 
@@ -233,8 +232,6 @@ If nothing is provided, all notes are shown."""
     @commands.max_concurrency(1, commands.BucketType.channel, wait=True)
     async def client_notes_add(self, ctx, *, note):
         """Store a note."""
-        await ctx.channel.trigger_typing()
-
         total_notes = len(await self.get_notes(ctx.author.id))
 
         if total_notes < self.max_notes_user:
@@ -305,7 +302,6 @@ The index parameter allows several formats:
 3-8  # delete notes 3 through 8
 To see a list of your notes and their indices, use the "notes show" command."""
         index: Iterable[int]
-        await ctx.channel.trigger_typing()
 
         note_list = await self.get_notes(ctx.author.id)
 

--- a/bot/cogs/notes.py
+++ b/bot/cogs/notes.py
@@ -153,8 +153,7 @@ If nothing is provided, all notes are shown."""
                 title=f'Note #{index+1:,}',
                 description=note['content'],
                 color=color,
-                timestamp=datetime.datetime.fromisoformat(
-                    note['time_of_entry'])
+                timestamp=note['time_of_entry']
             )
             return await ctx.send(embed=embed)
 

--- a/bot/cogs/prefix.py
+++ b/bot/cogs/prefix.py
@@ -81,8 +81,6 @@ For prefixes ending with a space or multi-word prefixes, specify it with double 
             ctx.command.reset_cooldown(ctx)
             return await ctx.send('An empty prefix is not allowed.')
 
-        await ctx.trigger_typing()
-
         current_prefix = (
             await db.get_prefix(ctx.guild.id)
         )

--- a/bot/cogs/prefix.py
+++ b/bot/cogs/prefix.py
@@ -97,9 +97,9 @@ For prefixes ending with a space or multi-word prefixes, specify it with double 
     @client_changeprefix.error
     async def client_changeprefix_error(self, ctx, error):
         error = getattr(error, 'original', error)
-        if isinstance(error, ValueError):
-            # Prefix is too long
+        if isinstance(error, ValueError):  # Prefix is too long
             await ctx.send(str(error))
+            ctx.handled = True
 
 
 

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -266,7 +266,7 @@ To remove only one reminder, use the removereminder command."""
         except IndexError:
             await ctx.send('That index does not exist.')
         else:
-            utcdue = datetime.datetime.fromisoformat(reminder['due'])
+            utcdue = reminder['due']
             embed = discord.Embed(
                 title=f'Reminder #{index:,}',
                 description=reminder['content'],
@@ -439,11 +439,9 @@ To remove only one reminder, use the removereminder command."""
         utcnow = datetime.datetime.utcnow()
 
         async for entry in db.yield_rows(db.TABLE_NAME):
-            utcwhen = datetime.datetime.fromisoformat(entry['due'])
-
             self.check_to_create_reminder(
                 entry['reminder_id'], entry['user_id'],
-                entry['content'], utcwhen, utcnow
+                entry['content'], entry['due'], utcnow
             )
 
     @send_reminders.before_loop

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -131,8 +131,6 @@ be used instead of UTC.
 
 Time is rounded down to the minute if seconds are not specified.
 You can have a maximum of 5 reminders."""
-        await ctx.channel.trigger_typing()
-
         total_reminders = len(await self.get_reminders(ctx.author.id))
 
         if total_reminders < 5:
@@ -197,8 +195,6 @@ You can have a maximum of 5 reminders."""
 
 To see a list of your reminders and their indices, use the showreminders command.
 To remove several reminders, use the removereminders command."""
-        await ctx.channel.trigger_typing()
-
         reminder_list = await self.get_reminders(ctx.author.id)
 
         if len(reminder_list) == 0:
@@ -223,8 +219,6 @@ To remove several reminders, use the removereminders command."""
 
 You can remove "all" of your reminders or remove only a section of it by specifying the start and end indices ("1-4").
 To remove only one reminder, use the removereminder command."""
-        await ctx.channel.trigger_typing()
-
         reminder_list = await self.get_reminders(ctx.author.id)
 
         if len(reminder_list) == 0:
@@ -257,8 +251,6 @@ To remove only one reminder, use the removereminder command."""
     @commands.cooldown(2, 5, commands.BucketType.user)
     async def client_showreminder(self, ctx, index: int):
         """Show one of your reminders."""
-        await ctx.channel.trigger_typing()
-
         reminder_list = await self.get_reminders(ctx.author.id)
 
         if len(reminder_list) == 0:
@@ -299,8 +291,6 @@ To remove only one reminder, use the removereminder command."""
     @commands.max_concurrency(1, commands.BucketType.channel, wait=True)
     async def client_showreminders(self, ctx):
         """Show all of your reminders."""
-        await ctx.channel.trigger_typing()
-
         reminder_list = await self.get_reminders(ctx.author.id)
 
         if len(reminder_list) == 0:

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -184,8 +184,8 @@ content: The new content to use."""
 
         if is_alias:
             alias = await ctx.bot.dbtags.get_alias(ctx.guild.id, name)
-            created_at = datetime.datetime.fromisoformat(alias['created_at'])
-            created_at = await ctx.bot.localize_datetime(ctx.author.id, created_at)
+            created_at = await ctx.bot.localize_datetime(
+                ctx.author.id, tag['created_at'])
 
             embed.title = alias['alias']
             embed.add_field(
@@ -202,8 +202,8 @@ content: The new content to use."""
 
             footer = 'Alias requested by {}'
         else:
-            created_at = datetime.datetime.fromisoformat(tag['created_at'])
-            created_at = await ctx.bot.localize_datetime(ctx.author.id, created_at)
+            created_at = await ctx.bot.localize_datetime(
+                ctx.author.id, tag['created_at'])
 
             embed.title = tag['name']
             embed.add_field(
@@ -226,9 +226,8 @@ content: The new content to use."""
                 )
 
             if tag['edited_at'] is not None:
-                edited_at = datetime.datetime.fromisoformat(tag['edited_at'])
                 edited_at = await ctx.bot.localize_datetime(
-                    ctx.author.id, edited_at)
+                    ctx.author.id, tag['edited_at'])
                 embed.add_field(
                     name='Last Edited',
                     value=utils.strftime_zone(edited_at),

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -41,7 +41,7 @@ class TagNameConverter(commands.Converter):
                 'with a reserved command name.'
             )
 
-        return arg
+        return arg.casefold()
 
 
 class TagPageSource(menus.AsyncIteratorPageSource):

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -307,6 +307,20 @@ content: The new content to use."""
         await ctx.send(embed=embed)
 
 
+    @client_tag.command(name='raw')
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def client_tag_raw(self, ctx, *, name: TagNameConverter('name')):
+        """Show a tag in its raw form.
+Useful for copy pasting any of the tag's markdown."""
+        tag = await ctx.bot.dbtags.get_tag(ctx.guild.id, name, include_aliases=True)
+        if tag is None:
+            return await ctx.send('This tag does not exist.')
+
+        escaped = discord.utils.escape_markdown(tag['content'])
+        for content in utils.paginate_message(escaped):
+            await ctx.send(content)
+
+
     @client_tag.command(name='reset')
     @commands.cooldown(1, 60, commands.BucketType.guild)
     @commands.guild_only()

--- a/bot/cogs/test.py
+++ b/bot/cogs/test.py
@@ -2,21 +2,8 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import collections
-import functools
-from typing import Union
-
 import discord
 from discord.ext import commands
-
-from bot import converters, utils
-
-
-def converter_partial(conv, *args, **kwargs):
-    class PartialConverter(conv):
-        def __init__(self):
-            super().__init__(*args, **kwargs)
-    return PartialConverter
 
 
 class Testing(commands.Cog, command_attrs={'hidden': True}):
@@ -32,85 +19,40 @@ class Testing(commands.Cog, command_attrs={'hidden': True}):
 
 
 
-    @commands.command(name='polltest')
-    async def client_poll(self, ctx):
-        yes = '\N{WHITE HEAVY CHECK MARK}'
-        no = '\N{CROSS MARK}'
-        choices = [yes, no]
-        m = await ctx.send('Poll test')
+    @commands.Cog.listener('on_socket_response')
+    async def on_button_interaction(self, m):
+        def map_buttons():
+            buttons = {}
+            for action_row in d['message']['components']:
+                for component in action_row['components']:
+                    custom_id = component.get('custom_id')
+                    if custom_id:
+                        buttons[custom_id] = component
+            return buttons
 
-        for e in choices:
-            await m.add_reaction(e)
-        await m.add_reaction('\N{OCTAGONAL SIGN}')
+        if m['t'] != 'INTERACTION_CREATE':
+            return
 
-        def check(r, u):
-            return (u == ctx.author and r.message == m
-                    and r.emoji == '\N{OCTAGONAL SIGN}')
+        d = m['d']
+        data = d['data']
 
-        try:
-            await ctx.bot.wait_for('reaction_add', check=check, timeout=30)
-        except asyncio.TimeoutError:
-            pass
+        if 'component_type' not in data:
+            return
 
-        m = await m.channel.fetch_message(m.id)
-
-        d = {}
-        for e in choices:
-            r = discord.utils.get(m.reactions, emoji=e)
-            d[e] = r.count - 1
-
-        result = '\n'.join([f'{k}: {v}' for k, v in d.items()])
-
-        await ctx.send(result)
-
-
-
-
-
-    @commands.command(name='getuser')
-    async def client_convert_user(
-            self, ctx, *, user: discord.User):
-        await ctx.send(str(user))
-
-
-
-
-
-    @commands.command(name='rolemoji')
-    async def client_role_emoji(
-            self, ctx, *args: Union[discord.Role,
-            converter_partial(converters.UnicodeEmojiConverter, partial_emoji=True)]):
-        names = ', '.join([x.name for x in args])
-        await ctx.send(names)
-
-
-
-
-
-    @commands.command(name='parsementions')
-    async def client_parse_mentions(
-            self, ctx, *mentions: commands.Greedy[
-                Union[discord.TextChannel, discord.Member]],
-            text: commands.clean_content):
-        # NOTE: when typehinted with discord.User, mentioning the bot
-        # gives ClientUser instead of User
-        c = collections.Counter(type(m) for m in mentions)
-
-        description = [
-            '{} mentions: {}'.format(
-                k.__name__.replace('Channel', ''),
-                v
-            )
-            for k, v in c.most_common()
-        ]
-        description = '\n'.join(description)
-
-        embed = discord.Embed(
-            color=utils.get_bot_color(ctx.bot),
-            description=description
+        route = discord.http.Route(
+            'POST', '/interactions/{id}/{token}/callback',
+            id=d['id'], token=d['token']
         )
 
-        await ctx.send(text, embed=embed)
+        # Get the button that was clicked
+        button = map_buttons()[data['custom_id']]
+
+        # send initial response
+        payload = {'type': 4, 'data': {
+            'content': f"Clicked {button['label']}",
+            'flags': 64  # makes message ephemeral/hidden
+        }}
+        await self.bot.http.request(route, json=payload)
 
 
 

--- a/bot/cogs/timezones.py
+++ b/bot/cogs/timezones.py
@@ -97,7 +97,7 @@ class Timezones(commands.Cog):
                 '%p' * (noon is not None)
             )
             # Include timezone in string only if it was parsed correctly
-            s = m[0] if given_tz else m[0][:m.start('tz')] if m['tz'] else m[0]
+            s = m[0] if not m['tz'] or given_tz else m[0][:m.start('tz') - m.start()]
             matches.append((s, dt, form))
 
             if i == limit:

--- a/bot/cogs/timezones.py
+++ b/bot/cogs/timezones.py
@@ -17,7 +17,7 @@ from bot.converters import TimezoneConverter
 from bot import utils
 
 
-class TranslationCheck(enum.IntEnum):
+class TranslationCheck(enum.Enum):
     SUCCESS = 0
     NO_GUILD = enum.auto()
     UN_REACTABLE = enum.auto()

--- a/bot/cogs/timezones.py
+++ b/bot/cogs/timezones.py
@@ -134,6 +134,10 @@ class Timezones(commands.Cog):
             return
 
         author_row = await self.bot.dbusers.get_user(m.author.id)
+
+        if not author_row['timezone_watch']:
+            return
+
         tz = await self.bot.dbusers.convert_timezone(author_row)
         if tz is None:
             return
@@ -426,6 +430,30 @@ By default, your timezone is hidden."""
         )
 
         await ctx.send('Updated your timezone visibility!')
+
+
+    @client_timezone.command(name='translation', aliases=('listen', 'watch'))
+    @commands.cooldown(2, 60, commands.BucketType.user)
+    async def client_timezone_watch(self, ctx, enabled: bool):
+        """Toggle timezone translations offered for your messages.
+If you have a timezone set and you send a time in your message, i.e. "8pm" or "15:30", the bot will react with a clock to allow other users to have the timezone translated for them.
+By default, this is enabled."""
+        row = await ctx.bot.dbusers.get_user(ctx.author.id)
+        curr_watch = row['timezone_watch']
+
+        if enabled and curr_watch:
+            return await ctx.send('Your timezone translation is already set to on!')
+        elif not enabled and not curr_watch:
+            return await ctx.send('Your timezone translation is already set to off!')
+
+        await ctx.bot.dbusers.update_rows(
+            ctx.bot.dbusers.TABLE_NAME,
+            {'timezone_watch': enabled},
+            where={'id': ctx.author.id}
+        )
+
+        action = 'Enabled' if enabled else 'Disabled'
+        await ctx.send(f'{action} timezone translation for your messages!')
 
 
 

--- a/bot/cogs/timezones.py
+++ b/bot/cogs/timezones.py
@@ -261,10 +261,8 @@ class Timezones(commands.Cog):
             nonlocal channel
             # Decide whether to get input in DMs or same channel
             form = (
-                'I do not know what timezone you are in! '
-                "Let's do that now; please __type in your timezone__.\n"
-                'If you do not know what timezone name you are in, '
-                'please use this Time Zone Map to find out: '
+                'To convert timezones, I need to know what timezone you are in! '
+                'Please type in your timezone as given by this timezone map:\n'
                 'https://kevinnovak.github.io/Time-Zone-Picker/\n'
                 'You have **3 minutes** to complete this form.'
             )

--- a/bot/cogs/uptime.py
+++ b/bot/cogs/uptime.py
@@ -37,21 +37,25 @@ class Uptime(commands.Cog):
         """Record a period of downtime."""
         self.bot.uptime_downtimes.append(DowntimePeriod(start, end))
         if vacuum:
-            self.vacuum_downtimes(limit=20)
+            self.vacuum_downtimes(before=datetime.timedelta(days=1))
 
 
     def vacuum_downtimes(self, *, before=None, limit=None):
         """Remove the oldest downtime entries.
 
         Args:
-            before (Optional[datetime.datetime]):
-                Removes downtimes before this datetime.
+            before (Optional[Union[datetime.datetime, datetime.timedelta]]):
+                Removes downtimes before this datetime. If a timedelta
+                is given, it is subtracted from the current time.
             limit (Optional[int]): Removes datetimes until the
                 deque size is at most this.
 
         """
         def before_filter():
-            while downtimes[0].end < before:
+            before_dt = before
+            if isinstance(before_dt, datetime.timedelta):
+                before_dt = datetime.datetime.now().astimezone() - before_dt
+            while downtimes[0].end < before_dt:
                 del downtimes[0]
 
         def limit_filter():

--- a/bot/database/currencydatabase.py
+++ b/bot/database/currencydatabase.py
@@ -22,9 +22,9 @@ class CurrencyDatabase(db.Database):
         cents INTEGER NOT NULL DEFAULT 0,
         CHECK (cents >= 0),
         PRIMARY KEY (guild_id, user_id),
-        FOREIGN KEY(guild_id) REFERENCES Guilds(id)
+        FOREIGN KEY (guild_id) REFERENCES Guilds(id)
             ON DELETE CASCADE,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/database.py
+++ b/bot/database/database.py
@@ -5,6 +5,7 @@
 import asyncio
 import dataclasses
 import os.path
+import sqlite3
 from typing import Tuple
 
 import asqlite
@@ -68,7 +69,15 @@ class ConnectionPool:
         conn_lock = self._connections.get(path)
         if conn_lock is None:
             conn_lock = (
-                await asqlite.connect(path),
+                await asqlite.connect(
+                    # detect_types will allow custom data types to be converted
+                    # such as DATE and TIMESTAMP
+                    # https://docs.python.org/3/library/sqlite3.html#default-adapters-and-converters
+                    path, detect_types=(
+                        sqlite3.PARSE_DECLTYPES
+                        | sqlite3.PARSE_COLNAMES
+                    )
+                ),
                 asyncio.Lock()
             )
             self._connections[path] = conn_lock

--- a/bot/database/gamedatabase.py
+++ b/bot/database/gamedatabase.py
@@ -21,7 +21,7 @@ class BlackjackDatabase(db.Database):
         wins INTEGER NOT NULL DEFAULT 0,
         losses INTEGER NOT NULL DEFAULT 0,
         blackjacks INTEGER NOT NULL DEFAULT 0,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/irishdatabase.py
+++ b/bot/database/irishdatabase.py
@@ -18,7 +18,7 @@ class ChargeDatabase(db.Database):
     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
         user_id INTEGER PRIMARY KEY NOT NULL,
         amount INTEGER NOT NULL DEFAULT 0,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/notedatabase.py
+++ b/bot/database/notedatabase.py
@@ -23,7 +23,7 @@ class NoteDatabase(db.Database):
         user_id INTEGER NOT NULL,
         time_of_entry TIMESTAMP,
         content TEXT NOT NULL,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/notedatabase.py
+++ b/bot/database/notedatabase.py
@@ -32,6 +32,8 @@ class NoteDatabase(db.Database):
                        content: str):
         """Add a note to the Notes table.
 
+        Note that the user should be in the database beforehand.
+
         Args:
             user_id (int)
             time_of_entry (datetime.datetime)

--- a/bot/database/prefixdatabase.py
+++ b/bot/database/prefixdatabase.py
@@ -21,7 +21,7 @@ class PrefixDatabase(db.Database):
     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
         guild_id INTEGER PRIMARY KEY NOT NULL,
         prefix TEXT NOT NULL,
-        FOREIGN KEY(guild_id) REFERENCES Guilds(id)
+        FOREIGN KEY (guild_id) REFERENCES Guilds(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/reminderdatabase.py
+++ b/bot/database/reminderdatabase.py
@@ -20,7 +20,7 @@ class ReminderDatabase(db.Database):
         user_id INTEGER NOT NULL,
         due TIMESTAMP,
         content TEXT NOT NULL,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
             ON DELETE CASCADE
     );
     """

--- a/bot/database/tagdatabase.py
+++ b/bot/database/tagdatabase.py
@@ -17,6 +17,7 @@ class TagDatabase(db.Database):
     """Provide an interface to the Tags table."""
 
     TABLE_NAME = 'Tags'
+    TABLE_ALIASES_NAME = 'TagAliases'
     TABLE_SETUP = f"""
     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
         guild_id INTEGER NOT NULL,
@@ -27,24 +28,76 @@ class TagDatabase(db.Database):
         created_at TIMESTAMP NOT NULL,
         edited_at TIMESTAMP,
         PRIMARY KEY (guild_id, name),
-        FOREIGN KEY(guild_id) REFERENCES Guilds(id)
+        FOREIGN KEY (guild_id) REFERENCES Guilds(id)
             ON DELETE CASCADE,
-        FOREIGN KEY(user_id) REFERENCES Users(id)
+        FOREIGN KEY (user_id) REFERENCES Users(id)
     );
     CREATE INDEX IF NOT EXISTS ix_tags_guilds ON {TABLE_NAME}(guild_id);
     CREATE INDEX IF NOT EXISTS ix_tags_users
         ON {TABLE_NAME}(guild_id, user_id);
+    CREATE TABLE IF NOT EXISTS {TABLE_ALIASES_NAME} (
+        guild_id INTEGER NOT NULL,
+        alias VARCHAR(50) NOT NULL,
+        name VARCHAR(50) NOT NULL,
+        user_id INTEGER NOT NULL,
+        created_at TIMESTAMP NOT NULL,
+        PRIMARY KEY (guild_id, alias),
+        FOREIGN KEY (guild_id) REFERENCES Guilds(id)
+            ON DELETE CASCADE,
+        FOREIGN KEY (guild_id, name) REFERENCES {TABLE_NAME}
+            ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES Users(id)
+    );
+    CREATE INDEX IF NOT EXISTS ix_tags_name_to_aliases
+        ON {TABLE_ALIASES_NAME}(guild_id, name);
+    -- Ensure both alias and name don't both exist together
+    CREATE TRIGGER IF NOT EXISTS no_tag_alias_if_name
+        AFTER INSERT ON {TABLE_ALIASES_NAME}
+        WHEN EXISTS (SELECT * FROM {TABLE_NAME} WHERE name=NEW.alias)
+        BEGIN
+            SELECT RAISE(ABORT, "a tag with the same name already exists");
+        END;
+    CREATE TRIGGER IF NOT EXISTS no_tag_name_if_alias
+        AFTER INSERT ON {TABLE_NAME}
+        WHEN EXISTS (SELECT * FROM {TABLE_ALIASES_NAME} WHERE alias=NEW.name)
+        BEGIN
+            SELECT RAISE(ABORT, "an alias with the same name already exists");
+        END;
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.__cache = {}
+        self.__cache = {}  # (guild_id, name): sqlite3.Row
+        self.__alias_cache = {}
+        # (guild_id, alias): (name, sqlite3.Row)
+
+    async def add_alias(
+            self, guild_id: int, alias: str, name: str, user_id: int) -> None:
+        """Add an alias for a tag and return the added row.
+
+        Raises:
+            sqlite3.IntegrityError: likely a tag with the same name
+                already exists.
+
+        """
+        guild_id, name = int(guild_id), str(name)
+        alias, user_id = str(alias), int(user_id)
+
+        d = {'guild_id': guild_id, 'name': name, 'alias': alias,
+             'user_id': user_id, 'created_at': datetime.datetime.utcnow()}
+
+        await self.add_row(self.TABLE_ALIASES_NAME, d)
+        return await self.get_alias(guild_id, alias)
 
     async def add_tag(
             self, guild_id: int, name: str, content: str, user_id: int):
         """Add a tag and return the added row.
 
         This also adds a user entry if needed.
+
+        Raises:
+            sqlite3.IntegrityError:
+                likely a tag or an alias with the same name already exists.
 
         """
         guild_id, user_id = int(guild_id), int(user_id)
@@ -57,6 +110,16 @@ class TagDatabase(db.Database):
         await self.add_row(self.TABLE_NAME, d)
         return await self.get_tag(guild_id, name)
 
+    async def delete_alias(self, guild_id: int, alias: str) -> None:
+        """Delete an alias."""
+        guild_id, alias = int(guild_id), str(alias)
+
+        # Update cache
+        self.__alias_cache.pop((guild_id, alias), None)
+
+        d = {'guild_id': guild_id, 'alias': alias}
+        await self.delete_rows(self.TABLE_ALIASES_NAME, d)
+
     async def delete_tag(self, guild_id: int, name: str):
         """Delete a tag and return the deleted rows.
 
@@ -67,10 +130,15 @@ class TagDatabase(db.Database):
         guild_id, name = int(guild_id), str(name)
 
         # Invalidate cache
-        self.__cache.pop((guild_id, name), None)
+        key = (guild_id, name)
+        self.__cache.pop(key, None)
+        aliases_to_remove = [
+            k for k, (orig, r) in list(self.__alias_cache.items()) if orig == name]
+        for k in aliases_to_remove:
+            del self.__alias_cache[k]
 
         d = {'guild_id': guild_id, 'name': name}
-        return await self.delete_rows(self.TABLE_NAME, d, pop=True)
+        rows = await self.delete_rows(self.TABLE_NAME, d, pop=True)
 
     async def edit_tag(self, guild_id: int, name: str,
                        content: str = None, uses: int = None,
@@ -105,17 +173,84 @@ class TagDatabase(db.Database):
         self.__cache.pop(key, None)
         return await self.get_tag(guild_id, name)
 
-    async def get_tag(self, guild_id: int, name: str):
-        """Get a tag from a guild."""
+    async def get_alias(self, guild_id: int, alias: str):
+        """Get a specific alias."""
+        guild_id, alias = int(guild_id), str(alias)
+
+        name_and_alias = self.__alias_cache.get((guild_id, alias))
+        if name_and_alias:
+            return name_and_alias[1]
+
+        d = {'guild_id': guild_id, 'alias': alias}
+        r = await self.get_one(self.TABLE_ALIASES_NAME, where=d)
+
+        if r:
+            self.__alias_cache[(guild_id, r['alias'])] = (r['name'], r)
+
+        return r
+
+    async def get_aliases(self, guild_id: int, name: str):
+        """Get all of a tag's aliases as a list of rows.
+
+        This will always do a database lookup, as the cache may only be
+        partially complete from some get_alias calls which is
+        indistinguishable from an actually complete cache of aliases.
+
+        Returns:
+            List[sqlite3.Row]
+
+        """
+        guild_id, name = int(guild_id), str(name)
+
+        aliases = await self.get_rows(
+            self.TABLE_ALIASES_NAME, where={
+                'guild_id': guild_id,
+                'name': name
+            }
+        )
+
+        for r in aliases:
+            self.__alias_cache[(guild_id, r['alias'])] = (name, r)
+
+        return aliases
+
+    async def get_tag(
+            self, guild_id: int, name: str, *, include_aliases=False):
+        """Get a tag from a guild.
+
+        NOTE: the number of columns in the row returned may vary
+        depending on caching. If include_aliases is True and the tag
+        was not cached, i.e. there wasn't a query where
+        include_aliases=False was successful, then a successful
+        fetch will return a row with columns from the aliases table being
+        included, which may be None if it matched the tag's name directly.
+
+        """
         guild_id, name = int(guild_id), str(name)
 
         key = (guild_id, name)
         tag = self.__cache.get(key)
+        if tag is None and include_aliases:
+            tag = self.__cache.get(self.__alias_cache.get(key))
         if tag is not None:
             return tag
 
-        d = {'guild_id': guild_id, 'name': name}
-        tag = await self.get_one(self.TABLE_NAME, where=d)
+        if include_aliases:
+            async with await self.connect() as conn:
+                async with conn.cursor() as c:
+                    t, t_aliases = self.TABLE_NAME, self.TABLE_ALIASES_NAME
+                    await c.execute(f"""
+                        SELECT * FROM {t} LEFT JOIN {t_aliases}
+                            ON {t}.name = {t_aliases}.name
+                        WHERE {t}.name = ? OR {t_aliases}.alias = ?
+                    """, name, name)
+                    tag = await c.fetchone()
+                    # Correct key to not use potential alias
+                    if tag:
+                        key = (guild_id, tag['name'])
+        else:
+            d = {'guild_id': guild_id, 'name': name}
+            tag = await self.get_one(self.TABLE_NAME, where=d)
         self.__cache[key] = tag
 
         return tag

--- a/bot/database/tagdatabase.py
+++ b/bot/database/tagdatabase.py
@@ -50,7 +50,7 @@ class TagDatabase(db.Database):
     );
     CREATE INDEX IF NOT EXISTS ix_tags_name_to_aliases
         ON {TABLE_ALIASES_NAME}(guild_id, name);
-    -- Ensure both alias and name don't both exist together
+    -- Ensure alias and name don't both exist together
     CREATE TRIGGER IF NOT EXISTS no_tag_alias_if_name
         AFTER INSERT ON {TABLE_ALIASES_NAME}
         WHEN EXISTS (SELECT * FROM {TABLE_NAME} WHERE name=NEW.alias)

--- a/bot/database/userdatabase.py
+++ b/bot/database/userdatabase.py
@@ -22,7 +22,8 @@ class UserDatabase(db.Database):
     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
         id INTEGER PRIMARY KEY NOT NULL,
         timezone TEXT,
-        timezone_public BOOLEAN NOT NULL DEFAULT false
+        timezone_public BOOLEAN NOT NULL DEFAULT false,
+        timezone_watch BOOLEAN NOT NULL DEFAULT true
     );
     """
 

--- a/bot/database/userdatabase.py
+++ b/bot/database/userdatabase.py
@@ -21,7 +21,8 @@ class UserDatabase(db.Database):
     TABLE_SETUP = f"""
     CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
         id INTEGER PRIMARY KEY NOT NULL,
-        timezone TEXT
+        timezone TEXT,
+        timezone_public BOOLEAN NOT NULL DEFAULT false
     );
     """
 
@@ -52,25 +53,20 @@ class UserDatabase(db.Database):
         user_id = int(user_id)
         return await self.delete_rows(self.TABLE_NAME, {'id': user_id})
 
-    async def get_timezone(self, user_id: int) -> Optional[pytz.BaseTzInfo]:
-        """Get the timezone of a given user.
+    async def convert_timezone(self, row) -> Optional[pytz.BaseTzInfo]:
+        """Get the timezone of a given user from a row provided
+        by get_user().
 
         In the case that an invalid timezone is inserted into the database,
-        this will nullify it before propagating the exception.
+        this will nullify it and then propagate the exception.
 
-        If the user entry does not exist, this will return None
-        without adding a new row.
+        Args:
+            row (sqlite3.Row): The user row to produce the timezone from.
+                Technically this could be any object, so long as
+                the "timezone" and "id" keys exist.
 
         """
-        user_id = int(user_id)
-
-        async with await self.connect() as conn:
-            async with conn.execute(
-                    f'SELECT timezone FROM {self.TABLE_NAME} WHERE id=?',
-                    user_id) as c:
-                row = await c.fetchone()
-
-        timezone = row['timezone'] if row is not None else None
+        timezone = row['timezone']
         if timezone is None:
             return
 
@@ -78,7 +74,7 @@ class UserDatabase(db.Database):
             return pytz.timezone(timezone)
         except pytz.UnknownTimeZoneError:
             await self.update_rows(self.TABLE_NAME, {'timezone': None},
-                                   where={'id': user_id})
+                                   where={'id': row['id']})
             raise
 
     async def get_user(self, user_id: int):

--- a/bot/other/discordlogger.py
+++ b/bot/other/discordlogger.py
@@ -1,7 +1,3 @@
-#  Copyright (C) 2021 thegamecracks
-#  This Source Code Form is subject to the terms of the Mozilla Public
-#  License, v. 2.0. If a copy of the MPL was not distributed with this
-#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 
 logger = None

--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -42,10 +42,10 @@ def format_table(
 
     widths = [max(len(r[col]) for r in rows) for col in range(len(rows[0]))]
 
-    render = [render_row(r) for r in rows]
-
     if strip_trailing:
-        render = [r.rstrip() for r in render]
+        render = [render_row(r).rstrip() for r in rows]
+    else:
+        render = [render_row(r) for r in rows]
 
     if divs:
         length = max(len(r) for r in render)

--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -58,6 +58,12 @@ def format_table(
     return '\n'.join(render)
 
 
+def paginate_message(message: str, max_size: int = 2000) -> str:
+    """Paginate a string by max_size and yield each string."""
+    for i in range(0, len(message), max_size):
+        yield message[i:i + max_size]
+
+
 def truncate_message(
         message: str, max_size: int = 2000, max_lines: Optional[int] = None,
         placeholder: str = '[...]') -> str:

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ class TheGameBot(BotDatabaseMixin, commands.Bot):
             'games',
             'graphing',
             'guildirish',
+            'guildsignal',
             'images',
             'messagetracker',  # dependency of info
             'info',  # dependency of helpcommand

--- a/main.py
+++ b/main.py
@@ -221,4 +221,7 @@ async def main():
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except Exception:
+        logger.exception('Exception logged by asyncio.run()')

--- a/main.py
+++ b/main.py
@@ -30,6 +30,8 @@ DISABLED_INTENTS = (
     'voice_states', 'typing'
 )
 
+logger = discordlogger.get_logger()
+
 
 class TheGameBot(BotDatabaseMixin, commands.Bot):
     EXT_LIST = [
@@ -170,8 +172,6 @@ class TheGameBot(BotDatabaseMixin, commands.Bot):
                 await super().start(*args, **kwargs)
             except KeyboardInterrupt:
                 logger.info('KeyboardInterrupt: closing bot')
-            except Exception:
-                logger.exception('Exception raised in bot')
             finally:
                 await self.close()
 
@@ -189,8 +189,6 @@ async def main():
                         help='Enable privileged presences intent.')
 
     args = parser.parse_args()
-
-    logger = discordlogger.get_logger()
 
     token = os.getenv('PyDiscordBotToken')
     if token is None:

--- a/main.py
+++ b/main.py
@@ -216,8 +216,7 @@ async def main():
         await bot.wait_until_ready()
         bot.info_bootup_time = time.perf_counter() - start_time
 
-    loop = asyncio.get_running_loop()
-    loop.create_task(bootup_time(bot, start_time))
+    bot.loop.create_task(bootup_time(bot, start_time))
 
     await bot.start(token)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+abattlemetrics @ git+https://github.com/thegamecracks/abattlemetrics.git@0.0.2
 aiohttp==3.7.3
 asqlite @ git+https://github.com/thegamecracks/asqlite/@1d0b7da105679eab891df927f1fc230775194fe4
 astunparse==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-abattlemetrics @ git+https://github.com/thegamecracks/abattlemetrics.git@0.0.3
+abattlemetrics @ git+https://github.com/thegamecracks/abattlemetrics.git@v0.1.0
 aiohttp==3.7.3
 asqlite @ git+https://github.com/thegamecracks/asqlite/@1d0b7da105679eab891df927f1fc230775194fe4
 astunparse==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-abattlemetrics @ git+https://github.com/thegamecracks/abattlemetrics.git@0.0.2
+abattlemetrics @ git+https://github.com/thegamecracks/abattlemetrics.git@0.0.3
 aiohttp==3.7.3
 asqlite @ git+https://github.com/thegamecracks/asqlite/@1d0b7da105679eab891df927f1fc230775194fe4
 astunparse==1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ chardet==3.0.4
 colorama==0.4.4
 cycler==0.10.0
 dateparser==1.0.0
+discord-ext-menus @ git+https://github.com/Rapptz/discord-ext-menus@309c70222eec33acacb8c21bbb0fbe9bc57de661
 discord-py-slash-command==1.1.1
 discord.py==1.7.2
 disputils==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ import-expression==1.1.4
 inflect==5.2.0
 jishaku==1.20.0.220
 kiwisolver==1.3.1
-matplotlib==3.4.1
+matplotlib==3.4.2
 multidict==4.7.6
 numpy==1.19.4
 packaging==20.4
@@ -31,6 +31,7 @@ python-dateutil==2.8.1
 pytz==2021.1
 qrcode==6.1
 regex==2021.3.17
+scipy==1.6.3
 six==1.15.0
 typing-extensions==3.7.4.3
 tzlocal==2.1


### PR DESCRIPTION
Additions:
- Graphing cog
  - RelativeDateFormatter function to Graphing cog for use in axis formatters
- Signal Hill cog (new!)
  - Runs a server status
  - Makes use of the thegamecracks/abattlemetrics package
  - Commands:
    - "history": (Owner-only) Generate the server status's player count graph immediately.
    - "playtime": Get a player's name and server playtime in the last month by steam ID.
- Tags cog
  - Commands:
    - "tag alias": Create an alias for an existing tag.
    - "tag raw": Send a tag with its markdown escaped.
- Timezones cog
  - Commands:
    - "timezone check": Check if a message has times to translate. 
    - "timezone ignore": Remove the timezone translation emoji from a given message.
    - "timezone visibility": Toggle the visibility of your timezone. Hidden by default.
    - "timezone translation": Toggle whether the bot should react to your message when you send a time.
  - Timezone offsets are now picked up and preferred over the message author's timezone when translating timezones, allowing syntax like "8pm EST" or "12:30 America/Chicago"
- `utils.paginate_message()` which is basically `message_snip()` from the past but written in two lines
- `TheGameBot.strftime_user()` for automatically localizing a datetime and censoring the timezone info if needed
- `TheGameBot.localize_datetime()` now accepts either an int or sqlite3.Row for the first argument, the latter which skips refetching the row from the database
- `checks.used_in_guild()`: Check that a command is used in a particular guild. Supports multiple guild IDs.

Improvements:
- Moderation cog
  - "purge self" can now delete messages that appear to start with the bot's prefix if permissions permit it
  - All purge commands now send a count of how many messages were deleted from each member involved
- Tags cog
  - Adds reaction paginator and concurrency limits for "leaderboard" and "list"
    - Includes discord-ext-menus in requirements
  - Staff with Manage Server permission can now delete any tag/alias
  - Tag names are now casefolded
  - Includes parameter name in the error messages when improper format is given for a tag name
- Timezones cog
  - Times are now detected in messages first before accessing the database which is a lot better than opening it on every message
- Errors during commands are now sent to the user as an embed with the error message and a 4 digit hexadecimal error code which is also printed to the terminal
- Exceptions are now logged after asyncio.run(main()) which should cover more code, particularly before the bot starts
- Replaces `get_timezone()` with `convert_timezone()` which removes the logic for fetching the user from the database, so it should be combined with `get_user()` or removed in favor of the new helper methods
- Adds `add` kwarg to `UserDatabase.get_user()` which enables automatically adding a user row. This is True by default, which fixes some cases where an error was caused due to a None return. This solution seems more practical than adding a guard to every get_user().
- Adds `ignore` kwarg to `Database.add_row()` which toggles between "INSERT" and "INSERT OR IGNORE INTO"
- Local and cog command handlers can now prevent the global error handler from running by assigning to the context's `handled` attribute
- Allows sqlite connections to detect declared types and parse them from column names within queries, meaning custom types like DATE and TIMESTAMP are automatically converted (see https://docs.python.org/3/library/sqlite3.html#default-adapters-and-converters)
- `checks.is_in_guild()` now supports multiple guild IDs
- Adds minor optimization for `format_table()`

Tweaks:
- Informative cog
  - "about" command: Includes a github link in the embed description
  - "messagecount" command: Intermittent downtimes are no longer rendered in the graph
- Moderation cog
  - Adds guild only check for more appropriate error messages in DMs
  - "purge self" now also accessible to the bot owner
- Timezones cog
  - Prefer DMs when translating timezones
- Downtime Tracking: only downtimes over a day old are now removed rather than the last 20 downtimes
- form for getting the user's timezone

Fixes:
- Timezones cog
  - 12am and 12pm being parsed incorrectly
- "charges reset" and "charges vaccum" commands incorrectly connecting to database
- "userinfo" incorrectly copying the created_at timedelta for the joined_at field

Other:
- Replaces most usages of get_running_loop() with bot.loop
- Removes remnants of multiprocessing from graphing.py
- Removes most usages of `trigger_typing()` and replaces some with the context manager version, `typing()`
- Removes license notice from discordlogger.py
- After creating or editing a tag, the bot will delete the original message if possible and mention/reply to them
